### PR TITLE
Redirect to index.html on 403 error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -185,4 +185,10 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     acm_certificate_arn = var.ssl_certificate_arn
     ssl_support_method  = "sni-only"
   }
+
+  custom_error_response {
+    error_code = 403
+    error_caching_min_ttl = 10
+    response_page_path = "/index.html"
+  }
 }


### PR DESCRIPTION
CloudFront vyhodnoti chybejici soubor jako 403 => nastavil jsem redirect na /index.html