### PR TITLE
Fix custom error response by adding response code

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -190,5 +190,6 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     error_code = 403
     error_caching_min_ttl = 10
     response_page_path = "/index.html"
+    response_code = 403
   }
 }


### PR DESCRIPTION
Škoda, že Terraform o tomto nemá zmínku.
```
IllegalUpdate: Your request must specify both ResponsePagePath and ResponseCode together or both should be empty.
```

Tak se omlouvám za trochu nepořádku. Říkám si, zda by nějaký verify command od Terraformu by to odhalil nebo ne. 🤔 